### PR TITLE
Generic/InlineControlStructure: bail early for control structures without body

### DIFF
--- a/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
+++ b/src/Standards/Generic/Sniffs/ControlStructures/InlineControlStructureSniff.php
@@ -80,16 +80,23 @@ class InlineControlStructureSniff implements Sniff
             }
         }
 
-        if ($tokens[$stackPtr]['code'] === T_WHILE || $tokens[$stackPtr]['code'] === T_FOR) {
-            // This could be from a DO WHILE, which doesn't have an opening brace or a while/for without body.
+        if ($tokens[$stackPtr]['code'] !== T_DO) {
+            // This could be from a DO WHILE, which doesn't have an opening brace, or an
+            // else/elseif/if/for/foreach/while without body.
             if (isset($tokens[$stackPtr]['parenthesis_closer']) === true) {
-                $afterParensCloser = $phpcsFile->findNext(Tokens::$emptyTokens, ($tokens[$stackPtr]['parenthesis_closer'] + 1), null, true);
-                if ($afterParensCloser === false) {
+                $nextTokenIndex = ($tokens[$stackPtr]['parenthesis_closer'] + 1);
+            } else if ($tokens[$stackPtr]['code'] === T_ELSE) {
+                $nextTokenIndex = ($stackPtr + 1);
+            }
+
+            if (isset($nextTokenIndex) === true) {
+                $afterElseOrParensCloser = $phpcsFile->findNext(Tokens::$emptyTokens, $nextTokenIndex, null, true);
+                if ($afterElseOrParensCloser === false) {
                     // Live coding.
                     return;
                 }
 
-                if ($tokens[$afterParensCloser]['code'] === T_SEMICOLON) {
+                if ($tokens[$afterElseOrParensCloser]['code'] === T_SEMICOLON) {
                     $phpcsFile->recordMetric($stackPtr, 'Control structure defined inline', 'no');
                     return;
                 }
@@ -161,9 +168,7 @@ class InlineControlStructureSniff implements Sniff
             $closer = $stackPtr;
         }
 
-        if ($tokens[($closer + 1)]['code'] === T_WHITESPACE
-            || $tokens[($closer + 1)]['code'] === T_SEMICOLON
-        ) {
+        if ($tokens[($closer + 1)]['code'] === T_WHITESPACE) {
             $phpcsFile->fixer->addContent($closer, ' {');
         } else {
             $phpcsFile->fixer->addContent($closer, ' { ');
@@ -267,94 +272,66 @@ class InlineControlStructureSniff implements Sniff
             $endLine = $end;
         }
 
-        if ($next !== $end) {
-            if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
-                // Account for a comment on the end of the line.
-                for ($endLine = $end; $endLine < $phpcsFile->numTokens; $endLine++) {
-                    if (isset($tokens[($endLine + 1)]) === false
-                        || $tokens[$endLine]['line'] !== $tokens[($endLine + 1)]['line']
-                    ) {
-                        break;
-                    }
-                }
-
-                if (isset(Tokens::$commentTokens[$tokens[$endLine]['code']]) === false
-                    && ($tokens[$endLine]['code'] !== T_WHITESPACE
-                    || isset(Tokens::$commentTokens[$tokens[($endLine - 1)]['code']]) === false)
+        if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
+            // Account for a comment on the end of the line.
+            for ($endLine = $end; $endLine < $phpcsFile->numTokens; $endLine++) {
+                if (isset($tokens[($endLine + 1)]) === false
+                    || $tokens[$endLine]['line'] !== $tokens[($endLine + 1)]['line']
                 ) {
-                    $endLine = $end;
+                    break;
                 }
             }
 
-            if ($endLine !== $end) {
-                $endToken     = $endLine;
-                $addedContent = '';
-            } else {
-                $endToken     = $end;
-                $addedContent = $phpcsFile->eolChar;
-
-                if ($tokens[$end]['code'] !== T_SEMICOLON
-                    && $tokens[$end]['code'] !== T_CLOSE_CURLY_BRACKET
-                ) {
-                    $phpcsFile->fixer->addContent($end, '; ');
-                }
+            if (isset(Tokens::$commentTokens[$tokens[$endLine]['code']]) === false
+                && ($tokens[$endLine]['code'] !== T_WHITESPACE
+                || isset(Tokens::$commentTokens[$tokens[($endLine - 1)]['code']]) === false)
+            ) {
+                $endLine = $end;
             }
+        }
+
+        if ($endLine !== $end) {
+            $endToken     = $endLine;
+            $addedContent = '';
+        } else {
+            $endToken     = $end;
+            $addedContent = $phpcsFile->eolChar;
+
+            if ($tokens[$end]['code'] !== T_SEMICOLON
+                && $tokens[$end]['code'] !== T_CLOSE_CURLY_BRACKET
+            ) {
+                $phpcsFile->fixer->addContent($end, '; ');
+            }
+        }
 
             $next = $phpcsFile->findNext(T_WHITESPACE, ($endToken + 1), null, true);
-            if ($next !== false
-                && ($tokens[$next]['code'] === T_ELSE
-                || $tokens[$next]['code'] === T_ELSEIF)
-            ) {
-                $phpcsFile->fixer->addContentBefore($next, '} ');
-            } else {
-                $indent = '';
-                for ($first = $stackPtr; $first > 0; $first--) {
-                    if ($tokens[$first]['column'] === 1) {
-                        break;
-                    }
-                }
-
-                if ($tokens[$first]['code'] === T_WHITESPACE) {
-                    $indent = $tokens[$first]['content'];
-                } else if ($tokens[$first]['code'] === T_INLINE_HTML
-                    || $tokens[$first]['code'] === T_OPEN_TAG
-                ) {
-                    $addedContent = '';
-                }
-
-                $addedContent .= $indent.'}';
-                if ($next !== false && $tokens[$endToken]['code'] === T_COMMENT) {
-                    $addedContent .= $phpcsFile->eolChar;
-                }
-
-                $phpcsFile->fixer->addContent($endToken, $addedContent);
-            }//end if
+        if ($next !== false
+            && ($tokens[$next]['code'] === T_ELSE
+            || $tokens[$next]['code'] === T_ELSEIF)
+        ) {
+            $phpcsFile->fixer->addContentBefore($next, '} ');
         } else {
-            if ($nextContent === false || $tokens[$nextContent]['line'] !== $tokens[$end]['line']) {
-                // Account for a comment on the end of the line.
-                for ($endLine = $end; $endLine < $phpcsFile->numTokens; $endLine++) {
-                    if (isset($tokens[($endLine + 1)]) === false
-                        || $tokens[$endLine]['line'] !== $tokens[($endLine + 1)]['line']
-                    ) {
-                        break;
-                    }
-                }
-
-                if ($tokens[$endLine]['code'] !== T_COMMENT
-                    && ($tokens[$endLine]['code'] !== T_WHITESPACE
-                    || $tokens[($endLine - 1)]['code'] !== T_COMMENT)
-                ) {
-                    $endLine = $end;
+            $indent = '';
+            for ($first = $stackPtr; $first > 0; $first--) {
+                if ($tokens[$first]['column'] === 1) {
+                    break;
                 }
             }
 
-            if ($endLine !== $end) {
-                $phpcsFile->fixer->replaceToken($end, '');
-                $phpcsFile->fixer->addNewlineBefore($endLine);
-                $phpcsFile->fixer->addContent($endLine, '}');
-            } else {
-                $phpcsFile->fixer->replaceToken($end, '}');
+            if ($tokens[$first]['code'] === T_WHITESPACE) {
+                $indent = $tokens[$first]['content'];
+            } else if ($tokens[$first]['code'] === T_INLINE_HTML
+                || $tokens[$first]['code'] === T_OPEN_TAG
+            ) {
+                $addedContent = '';
             }
+
+            $addedContent .= $indent.'}';
+            if ($next !== false && $tokens[$endToken]['code'] === T_COMMENT) {
+                $addedContent .= $phpcsFile->eolChar;
+            }
+
+            $phpcsFile->fixer->addContent($endToken, $addedContent);
         }//end if
 
         $phpcsFile->fixer->endChangeset();

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc
@@ -276,3 +276,22 @@ function testFinally()
 if ($something) {
     echo 'hello';
 } else /* comment */ if ($somethingElse) echo 'hi';
+
+if ($sniffShouldBailEarly);
+
+if (false) {
+} elseif ($sniffShouldBailEarly);
+
+if (false) {
+} else if ($sniffShouldBailEarly);
+
+if (false) {
+} else ($sniffShouldGenerateError);
+
+if (false) {
+} else; // Sniff should bail early.
+
+foreach ($array as $sniffShouldBailEarly);
+
+foreach ($array as $sniffShouldBailEarly)
+	/* some comment */;

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.inc.fixed
@@ -314,3 +314,23 @@ if ($something) {
     echo 'hello';
 } else /* comment */ if ($somethingElse) { echo 'hi';
 }
+
+if ($sniffShouldBailEarly);
+
+if (false) {
+} elseif ($sniffShouldBailEarly);
+
+if (false) {
+} else if ($sniffShouldBailEarly);
+
+if (false) {
+} else { ($sniffShouldGenerateError);
+}
+
+if (false) {
+} else; // Sniff should bail early.
+
+foreach ($array as $sniffShouldBailEarly);
+
+foreach ($array as $sniffShouldBailEarly)
+	/* some comment */;

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.js
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.js
@@ -33,3 +33,18 @@ if ($("#myid").rotationDegrees()=='90')
 if (something) {
     alert('hello');
 } else /* comment */ if (somethingElse) alert('hi');
+
+if (sniffShouldBailEarly);
+
+if (false) {
+} else if (sniffShouldBailEarly);
+
+if (false) {
+} else (sniffShouldGenerateError);
+
+if (false) {
+} else; // Sniff should bail early.
+
+while (sniffShouldBailEarly);
+
+for (sniffShouldBailEarly; sniffShouldBailEarly > 0; sniffShouldBailEarly--);

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.js.fixed
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.1.js.fixed
@@ -42,3 +42,19 @@ if (something) {
     alert('hello');
 } else /* comment */ if (somethingElse) { alert('hi');
 }
+
+if (sniffShouldBailEarly);
+
+if (false) {
+} else if (sniffShouldBailEarly);
+
+if (false) {
+} else { (sniffShouldGenerateError);
+}
+
+if (false) {
+} else; // Sniff should bail early.
+
+while (sniffShouldBailEarly);
+
+for (sniffShouldBailEarly; sniffShouldBailEarly > 0; sniffShouldBailEarly--);

--- a/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
+++ b/src/Standards/Generic/Tests/ControlStructures/InlineControlStructureUnitTest.php
@@ -81,6 +81,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffUnitTest
                 260 => 1,
                 269 => 1,
                 278 => 1,
+                289 => 1,
             ];
 
         case 'InlineControlStructureUnitTest.1.js':
@@ -94,6 +95,7 @@ final class InlineControlStructureUnitTest extends AbstractSniffUnitTest
                 27 => 1,
                 30 => 1,
                 35 => 1,
+                43 => 1,
             ];
 
         default:


### PR DESCRIPTION
The sniff now consistently handles all control structures without a body, in both PHP and JS, by bailing early. Extending the existing behavior for `while` and `for` to also include `else`, `elseif`, `if`, and `foreach` (PHP only).

Previously, the sniff would incorrectly flag these empty control structures as inline control structures that needed curly braces. This change makes the behavior consistent across all control structures.

Additionally, this commit removes two code blocks from the fixer that became unnecessary:

First block: the sniff now bails early for all control structures without body, so the code will never reach the fixer if `$closer + 1` is `T_SEMICOLON`.

Second block: the original version of this condition was added in the early days by the commit that enabled this sniff to fix errors:

squizlabs/PHP_CodeSniffer@a54c619#diff-4b3945c2100b0a92a56509de1b797bf58ad804cf36233c95c492479b665655dcL108-L110

The only two tests that were added with the commit mentioned above that trigger the removed condition are tests using `while` loops without body:

squizlabs/PHP_CodeSniffer@a54c619#diff-4b3945c2100b0a92a56509de1b797bf58ad804cf36233c95c492479b665655dcL108-L110

Control structures without a body are the only cases where `$next` would be equal to `$end`. Thus, these are the only cases where the removed condition would be executed. But this commit and a previous one, changed the sniff to bail early and not get to the fixer part when handling control structures without a body. 13c803b changed the sniff to ignore while/for without a body and updated the existing tests (squizlabs/PHP_CodeSniffer@13c803b#diff-2f069f3fe33bacdfc80485b97303aec66c98c451d07e6d86e41982b81ab1a294L49-R51). While this commit expanded the same approach for else/elseif/if/foreach control structures.

<!-- Provide a general summary of your changes in the title above. -->

<!--
Please target the `master` branch when submitting your pull request, unless your change **only** applies to PHPCS 4.x.
-->

# Description
<!--
What do you want to achieve with this PR? Why did you write this code? What problem does this PR solve?
Describe your changes in detail and, if relevant, explain which choices you have made and why.
-->


## Suggested changelog entry
<!--
Please provide a short description of the change for the changelog.
This is only needed when this is an end-user, integrators or external standard maintainers facing change.
-->


## Related issues/external references

Fixes #


## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix _(non-breaking change which fixes an issue)_
- [ ] New feature _(non-breaking change which adds functionality)_
- [ ] Breaking change _(fix or feature that would cause existing functionality to change)_
    - [ ] This change is only breaking for integrators, not for external standards or end-users.
- [ ] Documentation improvement


## PR checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have checked there is no other PR open for the same change.
- [ ] I have read the [Contribution Guidelines](https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/.github/CONTRIBUTING.md).
- [ ] I grant the project the right to include and distribute the code under the BSD-3-Clause license (and I have the right to grant these rights).
- [ ] I have added tests to cover my changes.
- [ ] I have verified that the code complies with the projects coding standards.
- [ ] \[Required for new sniffs\] I have added XML documentation for the sniff.

<!--
============================================================================================
Please make sure your pull request passes all continuous integration checks!

PRs which are failing their CI checks will likely be ignored by the maintainers.

Small PRs using atomic, descriptive commits are hugely appreciated as it will make
reviewing your changes easier for the maintainers.
============================================================================================
-->
